### PR TITLE
Support SSH password input

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A Neovim plugin that wraps `rsync` to sync files between your local machine and a remote server. `sink.nvim` is especially useful for developing on remote servers. Rather than installing Neovim on the remote, edit your files locally using your dialed-in Neovim config and then quickly push files up to the server when you are ready to run them. 
 
+## Features
+
+- Run a default rsync command instantly with a single keymap
+- Interactively pick from multiple configured sync targets via `vim.ui.select`
+- SSH password support
+
 ## Requirements
 
 - Neovim 0.10+


### PR DESCRIPTION
Support SSH password input over stdio. This was accomplished by starting the process using `vim.fn.jobstart` with `pty = true`, searching the process output for a password prompt, prompting the user for their password with `vim.fn.inputsecret`, and then sending the password to the process with `vim.fn.chansend`.